### PR TITLE
Initial implementation of module registration and graceful shutdown

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
   "preset": "airbnb",
   "esnext": true,
-  "requireTrailingComma": false
+  "requireTrailingComma": false,
+  "requireShorthandArrowFunctions": false
 }


### PR DESCRIPTION
- Move to an instance-based implementation. (`let stok = new Stok()`)
- Move `createServer` to a instance method
- Add `registerModule` method for registering modules to be initialized/destroyed in startup/shutdown processes
- Add `shutdown` method for shutting down registered modules and stopping the Hapi server
- Disable `requireShorthandArrowFunctions` JSCS rule to fix `=>` syntax. 
  - TODO: Migrate to eslint
