### PR TITLE
Shut down modules in the order they are registered

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class Stok {
   }
 
   shutdown() {
-    return this._shutdownModules(this._registeredModules);
+    return this._shutdownModules(this._registeredModules.slice().reverse());
   }
 
   _registerShutdownSignals() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -69,7 +69,7 @@ exports.shutdown = {
 
     this.stok.shutdown()
       .catch((error) => {
-        test.deepEqual(invoked, ['Third', 'Second'], 'Shutdown order');
+        test.deepEqual(invoked, ['First', 'Second'], 'Shutdown order');
         test.strictEqual(error, providedError, 'Error propagates');
         test.done();
       });
@@ -102,7 +102,7 @@ exports.shutdown = {
 
     this.stok.shutdown()
       .then(() => {
-        test.deepEqual(invoked, ['Third', 'Second', 'First'], 'Shutdown order');
+        test.deepEqual(invoked, ['First', 'Second', 'Third'], 'Shutdown order');
         test.done();
       });
   }


### PR DESCRIPTION
The web server has to shut down first to ensure requests are handled properly

Ref CDIG-997
