### PR TITLE
Improve request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Creates a new `Stok` instance.
 
 Creates a Hapi server and a connection.
 
-* `options` (Object): Configuration options for [Hapi's `server.connection()`](http://hapijs.com/api#serverconnectionoptions).
+* `options` (Object): Configuration options for [Hapi's `server.connection()`](http://hapijs.com/api#serverconnectionoptions), plus the following options:
+  * `ipHeader` (String; optional): The name of the header that contains the client's IP, for use behind a proxy.
 
 _NOTE: `Stok` instances can only have one connection per server._
 _NOTE: [Routes have customized behavior](#routing)._

--- a/lib/common-log.js
+++ b/lib/common-log.js
@@ -1,0 +1,46 @@
+'use strict'
+
+// Based on hapi-common-log
+// https://github.com/rockbot/hapi-common-log
+//
+// Copyright (c) 2014, Raquel Vélez <raquel@rckbt.me>
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+const moment = require('moment-tokens')
+
+function toCommonLogFormat (request, options) {
+  const rawRequest = request.raw.req
+
+  const method = rawRequest.method
+  const path = rawRequest.url
+  const httpProtocol = rawRequest.client
+    ? rawRequest.client.npnProtocol
+    : 'HTTP/' + rawRequest.httpVersion
+
+  let clientIp = request.info.remoteAddress
+  if (options && options.ipHeader && request.headers[options.ipHeader]) {
+    clientIp = request.headers[options.ipHeader]
+  }
+
+  const clientId = '-'
+  const userId = request.id
+  const time = '[' + moment().strftime('%d/%b/%Y:%H:%M:%S %z') + ']'
+  const requestLine = '"' + [method, path, httpProtocol].join(' ') + '"'
+  const statusCode = request.response.statusCode || request.response.output.statusCode
+  const objectSize = '-'
+
+  return [clientIp, clientId, userId, time, requestLine, statusCode, objectSize].join(' ')
+}
+
+module.exports = toCommonLogFormat

--- a/lib/hapi-proxy.js
+++ b/lib/hapi-proxy.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Hapi = require('hapi')
+const Hoek = require('hoek')
 const requestLogger = require('./request-logger')
 const stokVersion = require('../package').version
 const util = require('./util')
@@ -40,6 +41,12 @@ class HapiProxy {
 
     this._hasConnection = true
 
+    // Pull out the IP header from the connection options.
+    // This is only for use in the request logger.
+    options = Hoek.clone(options)
+    const ipHeader = options.ipHeader
+    delete options.ipHeader
+
     // Create the connection, then prevent any additional connections from
     // being created
     const connection = this._server.connection(options)
@@ -50,7 +57,10 @@ class HapiProxy {
     })
 
     // Register common extensions and routes
-    return this._server.register(requestLogger)
+    return this._server.register({
+      register: requestLogger,
+      options: { ipHeader }
+    })
       .then(() => {
         this._registerHealthRoute()
       })

--- a/lib/request-logger.js
+++ b/lib/request-logger.js
@@ -1,5 +1,5 @@
 const bole = require('bole')
-const toCommonLogFormat = require('hapi-common-log')
+const toCommonLogFormat = require('./common-log')
 const version = require('../package').version
 
 exports.register = function (server, options, next) {
@@ -11,9 +11,9 @@ exports.register = function (server, options, next) {
     reply.continue()
   })
 
-  server.ext('onPostHandler', (request, reply) => {
+  server.ext('onPreResponse', (request, reply) => {
     const latency = Date.now() - request.timing.start
-    request.logger.info(toCommonLogFormat(request), `${latency}ms`)
+    request.logger.info(toCommonLogFormat(request, options), `${latency}ms`)
     reply.continue()
   })
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "bole": "2.0.0",
     "dotenv": "2.0.0",
     "hapi": "13.3.0",
-    "hapi-common-log": "1.1.0",
-    "hoek": "3.0.4"
+    "hoek": "3.0.4",
+    "moment-tokens": "1.0.0"
   },
   "devDependencies": {
     "nodeunit": "0.9.1",


### PR DESCRIPTION
Add `ipHeader` option for `Stok#createServer()` to handle getting the client IP
when a proxy server is used.

Moves the request logger form `onPostHandler` to `onPreResponse` to handle
responses from `onPreHandler`.

Adds support for getting the status code form Boom error replies.

Drops dependency on `hapi-common-log` as it seems like it may no longer be
maintained and we needed to apply an update to handle Boom error replies.
