### PR TITLE
HapiProxy: Gracefully handle non-function routes

### DIFF
--- a/lib/hapi-proxy.js
+++ b/lib/hapi-proxy.js
@@ -120,6 +120,11 @@ class HapiProxy {
 
         routes.forEach((route) => {
           const handler = route.handler
+
+          if (typeof handler !== 'function') {
+            return
+          }
+
           route.handler = (request, reply) => {
             const maybePromise = handler(request, reply)
             if (maybePromise) {


### PR DESCRIPTION
Route handlers are generally functions, but in some cases they are not.
For example, The inert plugin for Hapi (which adds static file and directory
handlers) uses objects that define which file or directory to serve, along with
other configuration options.